### PR TITLE
Changed mv to install to set perms so web-ui doesn't produce errors

### DIFF
--- a/pihole_conf.sh
+++ b/pihole_conf.sh
@@ -44,7 +44,6 @@ echo "Replacing $ADLIST_LIST_DEST with a new adlist.list file"
 install -m 744 "$tmp_adlists_list" "$ADLIST_LIST_DEST"
 rm "$tmp_adlists_list"
 
-
 echo "Updating gravity"
 [[ "$DRY_RUN" -eq "0" ]] && "$PIHOLE_BIN" -g
 

--- a/pihole_conf.sh
+++ b/pihole_conf.sh
@@ -41,7 +41,9 @@ do
 done < "$ADLIST_LIST_ADDONS_FILE"
 
 echo "Replacing $ADLIST_LIST_DEST with a new adlist.list file"
-mv "$tmp_adlists_list" "$ADLIST_LIST_DEST"
+install -m 744 "$tmp_adlists_list" "$ADLIST_LIST_DEST"
+rm "$tmp_adlists_list"
+
 
 echo "Updating gravity"
 [[ "$DRY_RUN" -eq "0" ]] && "$PIHOLE_BIN" -g


### PR DESCRIPTION
Using the install command instead of mv allows setting of permissions. This in turn avoids the web-ui producing an error on the settings page after running the script.

Install is part of coreutils so should be available on most systems.